### PR TITLE
Docker configuration updates

### DIFF
--- a/predbat/DOCS.md
+++ b/predbat/DOCS.md
@@ -61,6 +61,28 @@ docker run docker.io/library/predbat
 
 Look into the docker under /config/predbat.log for the logfiles
 
+## Running with docker compose
+
+* Download the contents of 'https://github.com/springfall2008/predbat_addon/tree/main/predbat' onto your machine
+* Go the the predbat/standalone directory
+* Update location for apps.yaml, dashboard.yaml and log files in the docker-compose (/config volume inside the container):
+```
+      - /path/to/predbat/files:/config
+```
+* Download apps.yaml from Predbat repo (https://github.com/springfall2008/batpred/blob/main/apps/predbat/config/apps.yaml) to location set above, and edit it as per the Predbat documentation.
+* Add ha_url / ha_key settings into apps.yaml.
+  * The ha_url must be your Home Assistant machine e.g. http://homeassistant.local:8123
+  * The ha_key must be the persistant key you can generate in Home Assistant in your user/security section
+
+
+* Start the container as follows:
+
+```
+docker compose up -d
+```
+
+When editing apps.yaml, remember to restart the container.
+
 ## Copyright
 
 ```text

--- a/predbat/requirements.txt
+++ b/predbat/requirements.txt
@@ -2,4 +2,4 @@ pytz
 requests
 pyyaml
 asyncio
-aiohttp==3.8.6
+aiohttp>=3.8.6

--- a/predbat/rootfs/bootstrap.py
+++ b/predbat/rootfs/bootstrap.py
@@ -13,7 +13,7 @@ if not os.path.exists(root):
     root = "./"
 
 # Download the latest Predbat release from Github
-if not os.path.exists(root + "/apps.yaml"):
+if not os.path.exists(root + "/predbat.py"):
     url = "https://api.github.com/repos/springfall2008/batpred/releases"
     print("Download Predbat release list from {}".format(url))
     try:
@@ -60,7 +60,9 @@ if not os.path.exists(root + "/apps.yaml"):
         shutil.unpack_archive(save_path, unzip_path)
         unzip_path = unzip_path + "/batpred-" + tag_name.replace("v", "")
         os.system("cp {}/apps/predbat/* {}".format(unzip_path, root))
-        os.system("cp {}/apps/predbat/config/* {}".format(unzip_path, root))
+        if not os.path.exists(root + "/apps.yaml"):
+            print("No apps.yaml found - extracting default.")
+            os.system("cp {}/apps/predbat/config/* {}".format(unzip_path, root))
     else:
         print("Error: Unable to find a valid Predbat release")
         print("Sleep 5 minutes before restarting")
@@ -68,8 +70,5 @@ if not os.path.exists(root + "/apps.yaml"):
         sys.exit(1)
 
 
-print("Startup")
-os.system("cd " + root + "; python3 hass.py")
+print("Bootstrapped!")
 
-print("Shutdown, sleeping 30 seconds before restarting")
-time.sleep(30)

--- a/predbat/rootfs/run.sh
+++ b/predbat/rootfs/run.sh
@@ -1,8 +1,35 @@
-echo "Running Predbat inside Add-on"
-echo "Your API key is: $SUPERVISOR_TOKEN"
+#!/bin/bash
+
+ROOT_DIR="/config"
+[[ -d ${ROOT_DIR} ]] || ROOT_DIR="./"
+
+if [[ -n ${SUPERVISOR_TOKEN} ]]; then
+  echo "Running Predbat inside Add-on"
+  echo "Your API key is: ${SUPERVISOR_TOKEN}"
+fi
+
 if [ -f /config/dev ]; then
     echo "Dev mode enabled, not copying hass.py"
 else
-    cp /hass.py /config/hass.py
+    [[ ! -f ${ROOT_DIR}/hass.py ]] && cp /hass.py ${ROOT_DIR}/hass.py
 fi
-python3 /startup.py $SUPERVISOR_TOKEN
+
+## Bootstrap predbat
+python3 /bootstrap.py 
+
+## Run
+if [[ $? -eq 0 ]]; then
+  echo "Starting Predbat..."
+  ## Loop if running in HA otherwise let container properties deal with restart
+  if [[ -n ${SUPERVISOR_TOKEN} ]]; then
+    while true; do
+      cd ${ROOT_DIR} && python3 hass.py
+      echo "Predbat crashed. Restarting in 5 seconds..."
+      sleep 5
+    done
+  else
+    cd ${ROOT_DIR} && python3 hass.py
+  fi
+else
+  echo "Bootstrap failed"
+fi

--- a/predbat/standalone/Dockerfile
+++ b/predbat/standalone/Dockerfile
@@ -1,30 +1,14 @@
-#install python en pip
-FROM ubuntu:noble
+FROM python:3-slim-bookworm
 
-# Set shell
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+WORKDIR /
+COPY /rootfs /
+COPY requirements.txt /
 
-RUN apt-get update
-RUN apt-get upgrade -y
-RUN apt-get dist-upgrade -y
-RUN apt-get install -y python3
-RUN apt-get install -y python3-pip
-RUN apt-get install -y python3-venv
-RUN apt-get install -y python3-requests
-RUN apt-get install -y python3-yaml
-#RUN apt-get install -y python3-asyncio
-RUN apt-get install -y python3-aiohttp
-RUN apt-get install csh
-RUN apt-get install -y python3-tz
-
-WORKDIR /config
-COPY rootfs /config
-
-#COPY requirements.txt /tmp/
-#RUN pip3 install -r /tmp/requirements.txt
+# Install dependencies
+RUN pip3 --no-cache-dir install -r /requirements.txt
 
 # Start app
-RUN chmod a+x run.csh
+RUN chmod a+x run.sh
 
 ARG BUILD_ARCH
 ARG BUILD_DATE
@@ -52,4 +36,4 @@ LABEL \
     org.opencontainers.image.revision=${BUILD_REF} \
     org.opencontainers.image.version=${BUILD_VERSION}
 
-CMD [ "csh", "-f", "run.csh"]
+ENTRYPOINT /run.sh

--- a/predbat/standalone/docker-compose.yml
+++ b/predbat/standalone/docker-compose.yml
@@ -1,0 +1,14 @@
+
+# Small container to run predbat 
+services:
+  predbat:
+    container_name: predbat 
+    image: predbat:latest
+    build: 
+      context: ../
+      dockerfile: ./standalone/Dockerfile
+    environment:
+      TZ: 'Europe/London'
+    volumes:
+      - /path/to/predbat/files:/config
+    restart: unless-stopped


### PR DESCRIPTION
2 general themes for this PR:
- Improve standalone container setup and add compose.
- Consolidate standalone and HA build and run as much as possible to reduce add-on/container maintenance from future predbat changes.

Assumptions:
- Majority of future work will be predbat.py and/or hass.py. On this basis, these changes reduce overhead for future changes.
- Supervisor token is always and only visible to top level run.sh when running as add-on.

Following changes made in this PR:
- Standalone container moved to Python3 Debian Slim - saves > 300MB container size. Also updated to build from the same requirements.txt as addon. Minor tweak to requirements.txt.
- startup.py  tweaked (and renamed) to a general bootstrap - start is outside this now. Download based on predbat.py rather than apps.yaml. Will also only download apps.yaml if not found to avoid overwriting existing configs.
- Single run.sh for container and add-on config. Different behaviour for restarts - auto restart if add-on but falls back to container properties (e.g. compose) when running as standalone container. (ASSUMPTION: supervisor token is always and only visible when running as add-on)
- Added docker compose to allow simple setup of standalone docker container.
- Documentation update

Other:
- **WARNING:** Standalone container setup has been running stably for several days. Add-on install no HAOS **not tested** (no environment available) but code lines up. Recommend testing before accepting PR to release.