### PR TITLE
Add Jinja2 to the addon requirements

### DIFF
--- a/predbat/config.yaml
+++ b/predbat/config.yaml
@@ -1,6 +1,6 @@
 ---
-name: Predbat Iain
-version: 1.2.0
+name: Predbat
+version: 1.2.1
 slug: predbat
 description: Home Battery Prediction and Control
 url: https://github.com/springfall2008/predbat_addon

--- a/predbat/config.yaml
+++ b/predbat/config.yaml
@@ -1,5 +1,5 @@
 ---
-name: predbat
+name: Predbat Iain
 version: 1.2.0
 slug: predbat
 description: Home Battery Prediction and Control

--- a/predbat/requirements.txt
+++ b/predbat/requirements.txt
@@ -3,3 +3,4 @@ requests
 pyyaml
 asyncio
 aiohttp==3.8.6
+Jinja2

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,4 +1,4 @@
 # https://developers.home-assistant.io/docs/add-ons/repository#repository-configuration
 name: Predbat add-on Iain
-url: 'https://github.com/springfall2008/predbat_addon'
+url: 'https://github.com/iainfogg/predbat_addon'
 maintainer: Trefor Southwell <tdlj@tdlj.net>

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,4 +1,4 @@
 # https://developers.home-assistant.io/docs/add-ons/repository#repository-configuration
-name: Predbat add-on Iain
-url: 'https://github.com/iainfogg/predbat_addon'
+name: Predbat add-on
+url: 'https://github.com/springfall2008/predbat_addon'
 maintainer: Trefor Southwell <tdlj@tdlj.net>

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,4 +1,4 @@
 # https://developers.home-assistant.io/docs/add-ons/repository#repository-configuration
-name: Predbat add-on
+name: Predbat add-on Iain
 url: 'https://github.com/springfall2008/predbat_addon'
 maintainer: Trefor Southwell <tdlj@tdlj.net>


### PR DESCRIPTION
To support upcoming web templating

I've bumped the version number by 0.0.1.

Presumably you also need to do a GitHub release to tell HA about it?