### PR TITLE
Fix Dockerfile for Debian 12 / HAOS 15.2 compatibility

### DIFF
--- a/predbat/Dockerfile
+++ b/predbat/Dockerfile
@@ -8,7 +8,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get dist-upgrade -y
-RUN apt-get install -y python3
+#RUN apt-get install -y python3
+RUN apt-get update && apt-get install -y --no-install-recommends python3-minimal
 RUN apt-get install -y python3-pip
 
 WORKDIR /app_data


### PR DESCRIPTION
Replaces `apt-get install -y python3` with `apt-get install -y --no-install-recommends python3-minimal`, which works on both Debian 11 and 12.
