### PR TITLE
Add Bat icon for ingress

### DIFF
--- a/predbat/config.yaml
+++ b/predbat/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Predbat
-version: 1.5.1
+version: 1.5.2
 slug: predbat
 description: Home Battery Prediction and Control
 url: https://github.com/springfall2008/predbat_addon
@@ -8,6 +8,7 @@ codenotary: tdlj@tdlj.net
 ingress: True
 ingress_port: 5052
 ingress_root: "/"
+panel_icon: mdi:bat
 ports:
   8199/tcp: 8199
 arch:


### PR DESCRIPTION
Updated version to 1.5.2 and added `mdi:bat` as the icon.